### PR TITLE
Fixed directly import error

### DIFF
--- a/.changeset/sweet-candles-beam.md
+++ b/.changeset/sweet-candles-beam.md
@@ -1,0 +1,5 @@
+---
+"twitch-clip-function": patch
+---
+
+Fixed module option of `tsconfig.json` to enable directly import. And enabled `skipLibCheck` to ignore type error of nodemodules.

--- a/.eslint/cspell.ts
+++ b/.eslint/cspell.ts
@@ -1,5 +1,6 @@
 import cspellPlugin from "@cspell/eslint-plugin"
 import { Linter } from "eslint"
+import { resolve } from "node:path"
 import cspellJson from "../cspell.json"
 import { sharedFiles } from "./shared"
 
@@ -13,7 +14,7 @@ export const cspellConfig: Linter.Config = {
       "warn",
       {
         autoFix: false,
-        configFile: new URL("../cspell.json", import.meta.url).toString(),
+        configFile: resolve(__dirname, "../cspell.json"),
         cspell: {},
         generateSuggestions: true,
         numSuggestions: 5,

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -2,8 +2,7 @@ import { TSESLint } from "@typescript-eslint/utils"
 import { Linter } from "eslint"
 import prettierConfig from "eslint-config-prettier"
 import typegen from "eslint-typegen"
-import { dirname, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
+import { resolve } from "node:path"
 import tseslint from "typescript-eslint"
 import {
   baseConfig,
@@ -28,11 +27,7 @@ const ignoresConfig: Linter.Config = {
   name: "eslint/ignores",
 }
 
-const tsConfigPath = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  "./tsconfig.json",
-)
-
+const tsConfigPath = resolve(__dirname, "./tsconfig.json")
 const languageOptionConfig = languageOptionFactory(tsConfigPath)
 
 const config: TSESLint.FlatConfig.ConfigArray = tseslint.config(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "noImplicitReturns": true,
@@ -12,7 +12,8 @@
     "baseUrl": "./",
     "traceResolution": true,
     "resolveJsonModule": true,
-    "types": ["@types/node", "@types/jest"]
+    "types": ["@types/node", "@types/jest"],
+    "skipLibCheck": true
   },
   "compileOnSave": true,
   "include": [


### PR DESCRIPTION


## Description

<!-- Add a brief description. -->
Fixed module option of `tsconfig.json` to enable directly import. 
And enabled `skipLibCheck` to ignore type error of nodemodules.

## Current behavior (updates)

<!-- Please describe the current behavior that you are modifying. -->
Directly import is unable by `ESNext` module setting.
## New behavior

<!-- Please describe the behavior or changes this PR adds. -->
Updated to use `commonjs` module.
## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No